### PR TITLE
Improve Windows compatibility

### DIFF
--- a/Install.py
+++ b/Install.py
@@ -1,6 +1,7 @@
 import subprocess
 import urllib.request
 import os
+import shutil
 from colorama import init, Fore, Style
 
 # Initialize colorama
@@ -68,8 +69,8 @@ def clone_github_repositories():
             else:
                 print(f"Replacing existing '{repo_name}'...")
 
-                # Remove existing directory
-                subprocess.run(['rm', '-rf', repo_name])
+                # Remove existing directory in a cross-platform manner
+                shutil.rmtree(repo_name, ignore_errors=True)
 
         print(f"\nInstalling dependencies...")
 

--- a/Kirmkit.py
+++ b/Kirmkit.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import requests
@@ -85,11 +86,11 @@ def run_nmap() -> None:
 def run_ddos() -> None:
     ip = input("Enter the target IP address: ")
     port = input("Enter the target port: ")
-    run_in_dir(['python3', 'DRipper.py', '-s', ip, '-p', port, '-t', '443'], DDOS_DIR)
+    run_in_dir([sys.executable, 'DRipper.py', '-s', ip, '-p', port, '-t', '443'], DDOS_DIR)
 
 
 def run_nitrogen() -> None:
-    run_in_dir(['python3', 'Nitro.py'], TOOLS_DIR)
+    run_in_dir([sys.executable, 'Nitro.py'], TOOLS_DIR)
 
 # Function to center text to the left with red box background for disclaimer
 def center_disclaimer(text: str, width: int = 80) -> str:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ git clone https://github.com/kirm1/KirmKit.git
 # Usage ⚡
 ----------
 
-Windows
-----------
+Windows (Command Prompt)
+-----------------------
 
-In PowerShell
+Open Command Prompt and run:
 ```bash
 cd KirmKit
 ```
@@ -23,7 +23,7 @@ cd KirmKit
 pip install -r requirements.txt
 ```
 ```bash
-python3 Install.py
+python Install.py
 ```
 Linux
 --------


### PR DESCRIPTION
## Summary
- make repo easier to use from Windows 11 Command Prompt
- use cross-platform removal in installer
- invoke Python scripts using the current interpreter

## Testing
- `python -m py_compile Install.py Kirmkit.py Tools/Nitro.py`
