### PR TITLE
Improve Windows compatibility

### DIFF
--- a/Install.py
+++ b/Install.py
@@ -1,10 +1,34 @@
 import subprocess
 import urllib.request
 import os
+import shutil
+import itertools
+import time
 from colorama import init, Fore, Style
 
 # Initialize colorama
 init(autoreset=True)
+
+# Download a file with a simple progress bar
+def download_with_progress(url: str, dest: str) -> None:
+    response = urllib.request.urlopen(url)
+    total = int(response.getheader('content-length', 0))
+    downloaded = 0
+    chunk = 8192
+    with open(dest, 'wb') as out_file:
+        while True:
+            data = response.read(chunk)
+            if not data:
+                break
+            out_file.write(data)
+            downloaded += len(data)
+            if total:
+                percent = downloaded * 100 // total
+                bar_len = 50
+                filled = int(bar_len * percent / 100)
+                bar = '=' * filled + ' ' * (bar_len - filled)
+                print(f"\rDownloading: [{bar}] {percent}%", end='', flush=True)
+    print()
 
 # Function to display the KIRMKIT banner
 def display_banner():
@@ -22,35 +46,58 @@ def check_nmap_installation():
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
 
+# Check if Chocolatey (choco) is installed on Windows
+def check_choco_installation() -> bool:
+    return shutil.which('choco') is not None
+
+# Install Chocolatey package manager on Windows
+def install_choco() -> None:
+    print("\nChocolatey not found. Installing Chocolatey...")
+    cmd = [
+        'powershell',
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-Command', (
+            "Set-ExecutionPolicy Bypass -Scope Process -Force;"
+            "[System.Net.ServicePointManager]::SecurityProtocol ="
+            " [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;"
+            " iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"
+        )
+    ]
+    subprocess.run(cmd, check=True)
+
+# Run a command and display a simple progress bar while it executes
+def run_with_progress(cmd: list[str]) -> int:
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    spinner = itertools.cycle(['|', '/', '-', '\\'])
+    while process.poll() is None:
+        print(f"\rInstalling: {next(spinner)}", end='', flush=True)
+        time.sleep(0.1)
+    print('\r', end='', flush=True)
+    output = process.stdout.read() if process.stdout else ''
+    if output:
+        print(output)
+    return process.returncode
+
 # Function to download and run the Nmap installer with elevated privileges
 def install_nmap():
-    print(f"\nDownloading and installing {Fore.RED}[{Fore.GREEN}nmap{Style.RESET_ALL}{Fore.RED}]{Style.RESET_ALL}...")
+    print(f"\nInstalling {Fore.RED}[{Fore.GREEN}nmap{Style.RESET_ALL}{Fore.RED}]{Style.RESET_ALL}...")
 
-    # Download the Nmap installer
-    nmap_installer_url = "https://nmap.org/dist/nmap-7.94-setup.exe" if os.name == 'nt' else None
-
-    if nmap_installer_url:
-        installer_path = "nmap_setup.exe"
-        urllib.request.urlretrieve(nmap_installer_url, installer_path)
-
-        # Run the installer with elevated privileges
-        result = subprocess.run(['nmap_setup.exe'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-
-        if result.returncode == 0:
+    if os.name == 'nt':
+        if not check_choco_installation():
+            install_choco()
+        result = run_with_progress(['choco', 'install', 'nmap', '-y'])
+        if result == 0:
             print(f"{Fore.RED}[{Fore.GREEN}KirmKit{Style.RESET_ALL}{Fore.RED}]{Style.RESET_ALL} Installation Successful!")
         else:
             print(f"[{Fore.RED}ERROR{Style.RESET_ALL}] KirmKit installation failed.")
-            print(result.stderr.decode())
             exit(1)
     else:
-        # Linux platform, use package manager for installation
-        result = subprocess.run(['sudo', 'apt-get', 'install', 'nmap'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-        if result.returncode == 0:
+        result = run_with_progress(['sudo', 'apt-get', '-y', 'install', 'nmap'])
+        if result == 0:
             print(f"{Fore.RED}[{Fore.GREEN}KirmKit{Style.RESET_ALL}{Fore.RED}]{Style.RESET_ALL} Installation Successful!")
         else:
             print(f"[{Fore.RED}ERROR{Style.RESET_ALL}] KirmKit installation failed.")
-            print(result.stderr.decode())
             exit(1)
 
 # Function to clone GitHub repositories
@@ -68,8 +115,8 @@ def clone_github_repositories():
             else:
                 print(f"Replacing existing '{repo_name}'...")
 
-                # Remove existing directory
-                subprocess.run(['rm', '-rf', repo_name])
+                # Remove existing directory in a cross-platform manner
+                shutil.rmtree(repo_name, ignore_errors=True)
 
         print(f"\nInstalling dependencies...")
 

--- a/Kirmkit.py
+++ b/Kirmkit.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import requests
@@ -85,11 +86,11 @@ def run_nmap() -> None:
 def run_ddos() -> None:
     ip = input("Enter the target IP address: ")
     port = input("Enter the target port: ")
-    run_in_dir(['python3', 'DRipper.py', '-s', ip, '-p', port, '-t', '443'], DDOS_DIR)
+    run_in_dir([sys.executable, 'DRipper.py', '-s', ip, '-p', port, '-t', '443'], DDOS_DIR)
 
 
 def run_nitrogen() -> None:
-    run_in_dir(['python3', 'Nitro.py'], TOOLS_DIR)
+    run_in_dir([sys.executable, 'Nitro.py'], TOOLS_DIR)
 
 # Function to center text to the left with red box background for disclaimer
 def center_disclaimer(text: str, width: int = 80) -> str:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ git clone https://github.com/kirm1/KirmKit.git
 # Usage ⚡
 ----------
 
-Windows
-----------
+Windows (Command Prompt)
+-----------------------
 
-In PowerShell
+Open Command Prompt and run:
 ```bash
 cd KirmKit
 ```
@@ -23,8 +23,9 @@ cd KirmKit
 pip install -r requirements.txt
 ```
 ```bash
-python3 Install.py
+python Install.py
 ```
+Install.py installs Nmap via [Chocolatey](https://chocolatey.org/) with a progress bar. Chocolatey is automatically installed if needed.
 Linux
 --------
 


### PR DESCRIPTION
## Summary
- make repo easier to use from Windows 11 Command Prompt
- use cross-platform removal in installer
- invoke Python scripts using the current interpreter
- add progress bar and silent installer for nmap
- use Chocolatey to install nmap on Windows

## Testing
- `python -m py_compile Install.py Kirmkit.py Tools/Nitro.py`
